### PR TITLE
stop safely when redmine api key not set

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,12 @@ async function run() {
     const config = {
       apiKey: core.getInput('redmine_apikey')
     };
+    if (config.apiKey == '') {
+      console.log("redmine apikey has not set. ignored");
+      process.eixtCode = 0;
+      return
+    }
+
     const redmine = new Redmine(hostname, config);
     const pr = await octokit.rest.pulls.get({
       owner: context.repo.owner,


### PR DESCRIPTION
If redmine api key not set, this action failed as error.
This happens when dependabot create pull request.
see: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

Do not treat as error when redmine api key not set.